### PR TITLE
esm2_adapter model is now registered

### DIFF
--- a/src/byprot/models/fixedbb/lm_design/__init__.py
+++ b/src/byprot/models/fixedbb/lm_design/__init__.py
@@ -1,0 +1,1 @@
+from .esm2_adapter import ESM2Adapter

--- a/src/byprot/models/fixedbb/lm_design/modules/__init__.py
+++ b/src/byprot/models/fixedbb/lm_design/modules/__init__.py
@@ -1,0 +1,1 @@
+from .esm2_adapter import ESM2WithStructuralAdatper

--- a/src/byprot/models/fixedbb/protein_mpnn_cmlm/__init__.py
+++ b/src/byprot/models/fixedbb/protein_mpnn_cmlm/__init__.py
@@ -1,0 +1,1 @@
+from .protein_mpnn import ProteinMPNNCMLM, ProteinMPNNConfig


### PR DESCRIPTION
Before `@register_model('esm2_adapter')` was not actually registering the model.

Now, for those that do `pip install git+https://github.com/BytedProtein/ByProt.git`, you can use a model that uses `esm2_adapter`.
For example if your config.yaml contains:
```
model:
  _target_: esm2_adapter
```