### PR TITLE
Install two missing pkgs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,5 +4,5 @@ pip install -e .
 pip install -e vendor/esm
 
 pip install torch-scatter torch-sparse torch-cluster torch-spline-conv -f https://data.pyg.org/whl/torch-1.12.0+cu113.html
-pip install torch_geometric biotite
+pip install torch_geometric biotite lmdb tmtools
 pip install dgl-cu113 dglgo -f https://data.dgl.ai/wheels/repo.html


### PR DESCRIPTION
Hi @zhengzx-nlp ,
The two pkgs `lmdb` and  `tmtools`are used but not explicitly installed. Added to the `install.sh`.
Btw, great work I really enjoyed the insight! :)